### PR TITLE
Meetup iCal sources (VT Tech, NW VT, UX Speakeasy), CLI env, Turbopack root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies
 node_modules
+.pnpm-store/
 .pnp
 .pnp.js
 

--- a/lib/adapters/ical.ts
+++ b/lib/adapters/ical.ts
@@ -19,10 +19,11 @@ import type {
 } from 'node-ical';
 import { z } from 'zod';
 
+import { eventCategoryEnum } from '@/lib/db/schema';
 import { DEFAULT_TZ, toUtc } from '@/lib/tz';
 
 import { isAllowed } from './helpers/robots';
-import type { Adapter, AdapterContext, AdapterEvent } from './types';
+import type { Adapter, AdapterContext, AdapterEvent, EventCategory } from './types';
 import { RobotsDisallowedError } from './types';
 
 /* ------------------------------------------------------------------ */
@@ -38,6 +39,8 @@ const UA = 'VermontEventsBot/1.0';
 const configSchema = z
   .object({
     tzid: z.string().optional(),
+    /** When set, every VEVENT from this feed gets this category (e.g. Meetup tech calendars). */
+    default_category: z.enum(eventCategoryEnum.enumValues).optional(),
   })
   .optional();
 
@@ -108,6 +111,7 @@ export const icalAdapter: Adapter = {
     // 2. Parse config for default TZID override
     const cfg = configSchema.parse(source.adapter_config);
     const defaultTz = cfg?.tzid ?? DEFAULT_TZ;
+    const defaultCategory = cfg?.default_category;
 
     // 3. Fetch + parse the iCal feed
     // The type definitions for fromURL with options claim void return, but at
@@ -140,10 +144,17 @@ export const icalAdapter: Adapter = {
 
       if (event.rrule) {
         // -- Recurring event --
-        yield* expandRecurring(event, now, horizon, defaultTz, isAllDay, log);
+        yield* expandRecurring(event, now, horizon, defaultTz, isAllDay, log, defaultCategory);
       } else {
         // -- Single-occurrence event --
-        yield buildAdapterEvent(event, event.start, event.end, defaultTz, isAllDay);
+        yield buildAdapterEvent(
+          event,
+          event.start,
+          event.end,
+          defaultTz,
+          isAllDay,
+          defaultCategory,
+        );
       }
     }
   },
@@ -160,6 +171,7 @@ function* expandRecurring(
   defaultTz: string,
   isAllDay: boolean,
   log: { debug: (msg: string, extra?: Record<string, unknown>) => void },
+  defaultCategory: EventCategory | undefined,
 ): Generator<AdapterEvent> {
   const occurrences = event.rrule!.between(now, horizon);
   const exdateSet = buildExdateSet(event.exdate);
@@ -176,7 +188,15 @@ function* expandRecurring(
       continue;
     }
 
-    yield buildOccurrenceEvent(event, occDate, occKey, durationMs, defaultTz, isAllDay);
+    yield buildOccurrenceEvent(
+      event,
+      occDate,
+      occKey,
+      durationMs,
+      defaultTz,
+      isAllDay,
+      defaultCategory,
+    );
   }
 }
 
@@ -188,6 +208,7 @@ function buildOccurrenceEvent(
   durationMs: number,
   defaultTz: string,
   isAllDay: boolean,
+  defaultCategory: EventCategory | undefined,
 ): AdapterEvent {
   const override = event.recurrences?.[occKey] as Omit<VEvent, 'recurrences'> | undefined;
 
@@ -198,6 +219,7 @@ function buildOccurrenceEvent(
       override.end as DateWithTimeZone | undefined,
       defaultTz,
       override.datetype === 'date',
+      defaultCategory,
     );
   }
 
@@ -211,7 +233,7 @@ function buildOccurrenceEvent(
       }) as DateWithTimeZone)
     : undefined;
 
-  return buildAdapterEvent(event, occStart, occEnd, defaultTz, isAllDay);
+  return buildAdapterEvent(event, occStart, occEnd, defaultTz, isAllDay, defaultCategory);
 }
 
 /** Collect EXDATE entries into a Set of date-only keys for fast lookup. */
@@ -239,6 +261,7 @@ function buildAdapterEvent(
   end: DateWithTimeZone | undefined,
   defaultTz: string,
   allDay: boolean,
+  defaultCategory: EventCategory | undefined,
 ): AdapterEvent {
   const vEvent = event as VEvent;
   const title = paramVal(vEvent.summary) ?? '';
@@ -262,5 +285,6 @@ function buildAdapterEvent(
     allDay: allDay || undefined,
     venueName: location,
     url: resolvedUrl,
+    ...(defaultCategory ? { category: defaultCategory } : {}),
   };
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,15 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import type { NextConfig } from 'next';
 
+/** Repo root (where package.json / node_modules/next live). Turbopack can mis-infer `./app` as root. */
+const turbopackRoot = path.dirname(fileURLToPath(import.meta.url));
+
 const nextConfig: NextConfig = {
+  turbopack: {
+    root: turbopackRoot,
+  },
   serverExternalPackages: ['@neondatabase/serverless', 'drizzle-orm', 'node-ical', 'ws'],
 };
 

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "db:migrate": "drizzle-kit migrate",
     "format": "prettier --write .",
     "prepare": "husky",
-    "seed:fixtures": "tsx --env-file-if-exists=.env.local scripts/seed-fixtures.ts",
-    "seed:sources": "tsx --env-file-if-exists=.env.local scripts/seed-sources.ts",
-    "add:vcet": "tsx --env-file-if-exists=.env.local scripts/add-vcet.ts",
-    "add:meetup": "tsx --env-file-if-exists=.env.local scripts/add-meetup.ts",
-    "wipe:events": "tsx --env-file-if-exists=.env.local scripts/wipe-events.ts",
-    "add:category:tech": "tsx --env-file-if-exists=.env.local scripts/add-category-tech.ts"
+    "seed:fixtures": "tsx --import ./scripts/register-env.ts scripts/seed-fixtures.ts",
+    "seed:sources": "tsx --import ./scripts/register-env.ts scripts/seed-sources.ts",
+    "add:vcet": "tsx --import ./scripts/register-env.ts scripts/add-vcet.ts",
+    "add:meetup": "tsx --import ./scripts/register-env.ts scripts/add-meetup.ts",
+    "wipe:events": "tsx --import ./scripts/register-env.ts scripts/wipe-events.ts",
+    "add:category:tech": "tsx --import ./scripts/register-env.ts scripts/add-category-tech.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "seed:sources": "tsx --import ./scripts/register-env.ts scripts/seed-sources.ts",
     "add:vcet": "tsx --import ./scripts/register-env.ts scripts/add-vcet.ts",
     "add:meetup": "tsx --import ./scripts/register-env.ts scripts/add-meetup.ts",
+    "add:meetup:nw": "tsx --import ./scripts/register-env.ts scripts/add-meetup-nw-vt.ts",
+    "add:meetup:ux": "tsx --import ./scripts/register-env.ts scripts/add-meetup-ux-speakeasy-vt.ts",
     "wipe:events": "tsx --import ./scripts/register-env.ts scripts/wipe-events.ts",
     "add:category:tech": "tsx --import ./scripts/register-env.ts scripts/add-category-tech.ts"
   },

--- a/scripts/add-meetup-nw-vt.ts
+++ b/scripts/add-meetup-nw-vt.ts
@@ -1,0 +1,92 @@
+/**
+ * scripts/add-meetup-nw-vt.ts
+ *
+ * Adds NW Vermont Technology Meetups (Meetup iCal) to `sources`, then runs
+ * ingestion for that source. Idempotent upsert on `slug`.
+ *
+ * Usage: pnpm add:meetup:nw
+ *
+ * @see https://www.meetup.com/nw-vermont-technology-meetups/events/
+ */
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '@/lib/db/client';
+import { sources } from '@/lib/db/schema';
+import { runOne } from '@/lib/ingest/runner';
+
+const SOURCE = {
+  name: 'NW Vermont Technology Meetups',
+  slug: 'nw-vermont-technology-meetups',
+  kind: 'whitelist' as const,
+  adapter_type: 'ical' as const,
+  adapter_key: 'generic',
+  url: 'https://www.meetup.com/nw-vermont-technology-meetups/events/ical/',
+  adapter_config: { default_category: 'tech' } as Record<string, unknown>,
+  trust_level: 'auto_publish' as const,
+  is_active: true,
+  rate_limit_per_min: 30,
+  robots_respect: true,
+};
+
+async function main() {
+  console.log(`Upserting source: ${SOURCE.slug}`);
+
+  const result = await db
+    .insert(sources)
+    .values({
+      name: SOURCE.name,
+      slug: SOURCE.slug,
+      kind: SOURCE.kind,
+      adapter_type: SOURCE.adapter_type,
+      adapter_key: SOURCE.adapter_key,
+      url: SOURCE.url,
+      adapter_config: SOURCE.adapter_config,
+      trust_level: SOURCE.trust_level,
+      is_active: SOURCE.is_active,
+      rate_limit_per_min: SOURCE.rate_limit_per_min,
+      robots_respect: SOURCE.robots_respect,
+    })
+    .onConflictDoUpdate({
+      target: sources.slug,
+      set: {
+        name: sql`EXCLUDED.name`,
+        adapter_type: sql`EXCLUDED.adapter_type`,
+        adapter_key: sql`EXCLUDED.adapter_key`,
+        url: sql`EXCLUDED.url`,
+        adapter_config: sql`EXCLUDED.adapter_config`,
+        trust_level: sql`EXCLUDED.trust_level`,
+        is_active: sql`EXCLUDED.is_active`,
+        rate_limit_per_min: sql`EXCLUDED.rate_limit_per_min`,
+        robots_respect: sql`EXCLUDED.robots_respect`,
+        updated_at: sql`now()`,
+      },
+    })
+    .returning({ id: sources.id, slug: sources.slug, is_active: sources.is_active });
+
+  console.log('Upsert done:', result);
+
+  const row = result[0];
+  if (!row) {
+    throw new Error('Upsert returned no row');
+  }
+
+  console.log('Running ingestion (fetch iCal, persist events)...');
+  const summary = await runOne(row.id, 'manual');
+  console.log('Ingest finished:', {
+    status: summary.status,
+    itemsFound: summary.itemsFound,
+    itemsNew: summary.itemsNew,
+    itemsUpdated: summary.itemsUpdated,
+    itemsErrored: summary.itemsErrored,
+    itemsDedupSkipped: summary.itemsDedupSkipped,
+    durationMs: summary.durationMs,
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/scripts/add-meetup-ux-speakeasy-vt.ts
+++ b/scripts/add-meetup-ux-speakeasy-vt.ts
@@ -1,0 +1,92 @@
+/**
+ * scripts/add-meetup-ux-speakeasy-vt.ts
+ *
+ * Adds UX Speakeasy VT (Meetup iCal) to `sources`, then runs ingestion for that
+ * source. Idempotent upsert on `slug`.
+ *
+ * Usage: pnpm add:meetup:ux
+ *
+ * @see https://www.meetup.com/ux-speakeasy-vt/
+ */
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '@/lib/db/client';
+import { sources } from '@/lib/db/schema';
+import { runOne } from '@/lib/ingest/runner';
+
+const SOURCE = {
+  name: 'UX Speakeasy VT',
+  slug: 'ux-speakeasy-vt',
+  kind: 'whitelist' as const,
+  adapter_type: 'ical' as const,
+  adapter_key: 'generic',
+  url: 'https://www.meetup.com/ux-speakeasy-vt/events/ical/',
+  adapter_config: { default_category: 'tech' } as Record<string, unknown>,
+  trust_level: 'auto_publish' as const,
+  is_active: true,
+  rate_limit_per_min: 30,
+  robots_respect: true,
+};
+
+async function main() {
+  console.log(`Upserting source: ${SOURCE.slug}`);
+
+  const result = await db
+    .insert(sources)
+    .values({
+      name: SOURCE.name,
+      slug: SOURCE.slug,
+      kind: SOURCE.kind,
+      adapter_type: SOURCE.adapter_type,
+      adapter_key: SOURCE.adapter_key,
+      url: SOURCE.url,
+      adapter_config: SOURCE.adapter_config,
+      trust_level: SOURCE.trust_level,
+      is_active: SOURCE.is_active,
+      rate_limit_per_min: SOURCE.rate_limit_per_min,
+      robots_respect: SOURCE.robots_respect,
+    })
+    .onConflictDoUpdate({
+      target: sources.slug,
+      set: {
+        name: sql`EXCLUDED.name`,
+        adapter_type: sql`EXCLUDED.adapter_type`,
+        adapter_key: sql`EXCLUDED.adapter_key`,
+        url: sql`EXCLUDED.url`,
+        adapter_config: sql`EXCLUDED.adapter_config`,
+        trust_level: sql`EXCLUDED.trust_level`,
+        is_active: sql`EXCLUDED.is_active`,
+        rate_limit_per_min: sql`EXCLUDED.rate_limit_per_min`,
+        robots_respect: sql`EXCLUDED.robots_respect`,
+        updated_at: sql`now()`,
+      },
+    })
+    .returning({ id: sources.id, slug: sources.slug, is_active: sources.is_active });
+
+  console.log('Upsert done:', result);
+
+  const row = result[0];
+  if (!row) {
+    throw new Error('Upsert returned no row');
+  }
+
+  console.log('Running ingestion (fetch iCal, persist events)...');
+  const summary = await runOne(row.id, 'manual');
+  console.log('Ingest finished:', {
+    status: summary.status,
+    itemsFound: summary.itemsFound,
+    itemsNew: summary.itemsNew,
+    itemsUpdated: summary.itemsUpdated,
+    itemsErrored: summary.itemsErrored,
+    itemsDedupSkipped: summary.itemsDedupSkipped,
+    durationMs: summary.durationMs,
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/scripts/add-meetup.ts
+++ b/scripts/add-meetup.ts
@@ -1,0 +1,106 @@
+/**
+ * scripts/add-meetup.ts
+ *
+ * Adds a single source row (Vermont Technology Meetup iCal) to the `sources` table,
+ * then runs ingestion for that source so events appear on the public calendar.
+ * Idempotent upsert — uses ON CONFLICT (slug) DO UPDATE.
+ *
+ * Usage: pnpm add:meetup
+ *
+ * If you already ingested under `review` trust, events may be stuck in
+ * `pending_review` (hidden from the public calendar / feed.ics). After
+ * re-running this script, either approve them in admin or run:
+ *
+ *   UPDATE events SET status = 'published', published_at = COALESCE(published_at, now())
+ *   WHERE source_id = (SELECT id FROM sources WHERE slug = 'vermont-technology-meetup')
+ *     AND status = 'pending_review';
+ *
+ * Pattern for future ad-hoc source additions: copy `scripts/add-vcet.ts`,
+ * tweak the SOURCE constant, run with a new pnpm script alias.
+ */
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '@/lib/db/client';
+import { sources } from '@/lib/db/schema';
+import { runOne } from '@/lib/ingest/runner';
+
+const SOURCE = {
+  name: 'Vermont Technology Meetup',
+  slug: 'vermont-technology-meetup',
+  kind: 'whitelist' as const,
+  adapter_type: 'ical' as const,
+  adapter_key: 'generic',
+  url: 'https://www.meetup.com/vermont-technology-meetup/events/ical/',
+  // Generic iCal adapter: default_category is applied to every VEVENT.
+  adapter_config: { default_category: 'tech' } as Record<string, unknown>,
+  // Whitelist + auto_publish: new rows become `published` so they appear on the
+  // site and `/feed.ics`. `review` would leave every ingest as `pending_review`,
+  // which public queries intentionally exclude.
+  trust_level: 'auto_publish' as const,
+  is_active: true,
+  rate_limit_per_min: 30,
+  robots_respect: true,
+};
+
+async function main() {
+  console.log(`Upserting source: ${SOURCE.slug}`);
+
+  const result = await db
+    .insert(sources)
+    .values({
+      name: SOURCE.name,
+      slug: SOURCE.slug,
+      kind: SOURCE.kind,
+      adapter_type: SOURCE.adapter_type,
+      adapter_key: SOURCE.adapter_key,
+      url: SOURCE.url,
+      adapter_config: SOURCE.adapter_config,
+      trust_level: SOURCE.trust_level,
+      is_active: SOURCE.is_active,
+      rate_limit_per_min: SOURCE.rate_limit_per_min,
+      robots_respect: SOURCE.robots_respect,
+    })
+    .onConflictDoUpdate({
+      target: sources.slug,
+      set: {
+        name: sql`EXCLUDED.name`,
+        adapter_type: sql`EXCLUDED.adapter_type`,
+        adapter_key: sql`EXCLUDED.adapter_key`,
+        url: sql`EXCLUDED.url`,
+        adapter_config: sql`EXCLUDED.adapter_config`,
+        trust_level: sql`EXCLUDED.trust_level`,
+        is_active: sql`EXCLUDED.is_active`,
+        rate_limit_per_min: sql`EXCLUDED.rate_limit_per_min`,
+        robots_respect: sql`EXCLUDED.robots_respect`,
+        updated_at: sql`now()`,
+      },
+    })
+    .returning({ id: sources.id, slug: sources.slug, is_active: sources.is_active });
+
+  console.log('Upsert done:', result);
+
+  const row = result[0];
+  if (!row) {
+    throw new Error('Upsert returned no row');
+  }
+
+  console.log('Running ingestion (fetch iCal, persist events)...');
+  const summary = await runOne(row.id, 'manual');
+  console.log('Ingest finished:', {
+    status: summary.status,
+    itemsFound: summary.itemsFound,
+    itemsNew: summary.itemsNew,
+    itemsUpdated: summary.itemsUpdated,
+    itemsErrored: summary.itemsErrored,
+    itemsDedupSkipped: summary.itemsDedupSkipped,
+    durationMs: summary.durationMs,
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/scripts/register-env.ts
+++ b/scripts/register-env.ts
@@ -1,0 +1,43 @@
+/**
+ * Preload with: `tsx --import ./scripts/register-env.ts <script>`
+ *
+ * Loads `.env.local` into `process.env` before `@/lib/env` runs. Node 20 does not
+ * support `--env-file-if-exists`; plain `--env-file` fails when the file is absent.
+ *
+ * Handles common one-line `KEY=value` / `KEY="value"` entries; does not expand
+ * variable references (same limitation as many simple loaders).
+ *
+ * Duplicate keys in the file: **last assignment wins** (same as dotenv). Values
+ * are only applied when `process.env[key]` is still unset (shell / OS wins first).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const envPath = path.resolve(process.cwd(), '.env.local');
+if (fs.existsSync(envPath)) {
+  const text = fs.readFileSync(envPath, 'utf8');
+  const fromFile: Record<string, string> = {};
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    if (!key || key.startsWith('#')) continue;
+    let val = trimmed.slice(eq + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"') && val.length >= 2) ||
+      (val.startsWith("'") && val.endsWith("'") && val.length >= 2)
+    ) {
+      val = val.slice(1, -1);
+    }
+    fromFile[key] = val;
+  }
+
+  for (const [key, val] of Object.entries(fromFile)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = val;
+    }
+  }
+}

--- a/tests/unit/adapters/ical.test.ts
+++ b/tests/unit/adapters/ical.test.ts
@@ -196,6 +196,21 @@ describe('ical adapter', () => {
     });
   });
 
+  // ── 7. default_category from adapter_config ──
+  describe('default_category config', () => {
+    it('sets category on every yielded event when configured', async () => {
+      const ctx = buildCtx({
+        adapter_config: { default_category: 'tech' },
+      });
+      const events = await collectEvents(ctx);
+
+      expect(events.length).toBeGreaterThan(0);
+      for (const e of events) {
+        expect(e.category).toBe('tech');
+      }
+    });
+  });
+
   // ── Bonus: RRULE with recurrence override ──
   describe('RRULE with recurrence override', () => {
     it('uses override data for the overridden occurrence', async () => {


### PR DESCRIPTION
## Summary

Adds Meetup iCal whitelist sources with idempotent upsert and immediate ingestion (`runOne` after insert). Includes supporting fixes for local scripts and Turbopack.

## Sources (pnpm scripts)

| Script | Group |
|--------|--------|
| `pnpm add:meetup` | Vermont Technology Meetup |
| `pnpm add:meetup:nw` | NW Vermont Technology Meetups |
| `pnpm add:meetup:ux` | UX Speakeasy VT |

Each uses generic iCal adapter, `default_category: tech`, `auto_publish`, `robots_respect`, 30/min rate limit.

## Other changes

- **iCal adapter**: optional `default_category` in `adapter_config` (with unit test).
- **CLI env**: `scripts/register-env.ts` loaded via `tsx --import` (Node 20 lacks `--env-file-if-exists`); last duplicate key in `.env.local` wins within the file.
- **Next.js**: `turbopack.root` set to repo root to fix mis-inferred `./app` root.
- **.gitignore**: `.pnpm-store/`.

## Verify

- `pnpm add:meetup` (and `:nw`, `:ux`) against `.env.local` with valid env.
- Ingest logs show items when Meetup feeds have upcoming VEVENTs.


Made with [Cursor](https://cursor.com)